### PR TITLE
feat: PRDP-237 Add recover api IO_ERROR_TO_NOTIFY and GENERATED status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,145 @@
-# pagoPA Functions template
+# pagoPA Receipt-pdf-helpdesk
 
-Java template to create an Azure Function.
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pagopa_pagopa-receipt-pdf-helpdesk&metric=alert_status)](https://sonarcloud.io/dashboard?id=pagopa_pagopa-receipt-pdf-helpdesk)
 
-## Function examples
-There is an example of a Http Trigger function.
+Java Azure Functions that exposed the following recover APIs:
+- RecoverFailedReceipt
+- RecoverNotNotifiedReceipt
 
 ---
 
-## Run locally with Docker
-`docker build -t pagopa-functions-template .`
+## Summary 📖
 
-`docker run -p 8999:80 pagopa-functions-template`
+- [Api Documentation 📖](#api-documentation-)
+- [Start Project Locally 🚀](#start-project-locally-)
+  * [Run locally with Docker](#run-locally-with-docker)
+    + [Prerequisites](#prerequisites)
+    + [Run docker container](#run-docker-container)
+  * [Run locally with Maven](#run-locally-with-maven)
+    + [Prerequisites](#prerequisites-1)
+    + [Set environment variables](#set-environment-variables)
+    + [Run the project](#run-the-project)
+  * [Test](#test)
+- [Develop Locally 💻](#develop-locally-)
+  * [Prerequisites](#prerequisites-2)
+  * [Testing 🧪](#testing-)
+    + [Unit testing](#unit-testing)
+    + [Integration testing](#integration-testing)
+    + [Performance testing](#performance-testing)
+- [Contributors 👥](#contributors-)
+  * [Maintainers](#maintainers)
 
-### Test
-`curl http://localhost:8999/example`
+---
 
-## Run locally with Maven
+## Api Documentation 📖
+
+See
+the [OpenApi 3 here](https://editor.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pagopa-receipt-pdf-helpdesk/main/openapi/openapi.json)
+
+## Start Project Locally 🚀
+
+### Run locally with Docker
+
+#### Prerequisites
+
+- docker
+
+#### Set environment variables
+
+`docker build -t pagopa-receip-pdf-helpdesk .`
+
+`cp .env.example .env`
+
+and replace in `.env` with correct values
+
+#### Run docker container
+
+then type :
+
+`docker run -p 80:80 --env-file=./.env pagopa-receip-pdf-helpdesk`
+
+### Run locally with Maven
+
+#### Prerequisites
+
+- maven
+
+#### Set environment variables
+
+On terminal type:
+
+`cp local.settings.json.example local.settings.json`
+
+then replace env variables with correct values
+(if there is NO default value, the variable HAS to be defined)
+
+| VARIABLE                              | USAGE                                                                                                                           |                     DEFAULT VALUE                      |
+|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------:|
+| `RECEIPT_QUEUE_CONN_STRING`           | Connection string to the Receipt Queue                                                                                          |                                                        |
+| `RECEIPT_QUEUE_TOPIC`                 | Topic name of the Receipt Queue                                                                                                 |                                                        |
+| `COSMOS_BIZ_EVENT_CONN_STRING`        | Connection string to the BizEvent CosmosDB                                                                                      |                                                        |
+| `COSMOS_BIZ_EVENT_SERVICE_ENDPOINT`   | Endpoint to the BizEvent CosmosDB                                                                                               |                                                        |
+| `COSMOS_BIZ_EVENT_DB_NAME`            | Database name of the BizEvent database in CosmosDB                                                                              |                                                        |
+| `COSMOS_BIZ_EVENT_CONTAINER_NAME`     | Container name of the BizEvent container in CosmosDB                                                                            |                                                        |
+| `COSMOS_RECEIPTS_CONN_STRING`         | Connection string to the Receipt CosmosDB                                                                                       |                                                        |
+| `COSMOS_RECEIPT_SERVICE_ENDPOINT`     | Endpoint to the Receipt CosmosDB                                                                                                |                                                        |
+| `COSMOS_RECEIPT_KEY`                  | Key to the Receipt CosmosDB                                                                                                     |                                                        |
+| `COSMOS_RECEIPT_DB_NAME`              | Database name of the Receipt database in CosmosDB                                                                               |                                                        |
+| `COSMOS_RECEIPT_CONTAINER_NAME`       | Container name of the Receipt container in CosmosDB                                                                             |                                                        |
+| `PDV_TOKENIZER_BASE_PATH`             | PDV Tokenizer API base path                                                                                                     | "https://api.uat.tokenizer.pdv.pagopa.it/tokenizer/v1" |
+| `PDV_TOKENIZER_SEARCH_TOKEN_ENDPOINT` | PDV Tokenizer API search token endpoint                                                                                         |                    "/tokens/search"                    |
+| `PDV_TOKENIZER_FIND_PII_ENDPOINT`     | PDV Tokenizer API find pii endpoint                                                                                             |                    "/tokens/%s/pii"                    |
+| `PDV_TOKENIZER_CREATE_TOKEN_ENDPOINT` | PDV Tokenizer API create token endpoint                                                                                         |                       "/tokens"                        |
+| `PDV_TOKENIZER_SUBSCRIPTION_KEY`      | API azure ocp apim subscription key                                                                                             |                                                        |
+| `PDV_TOKENIZER_INITIAL_INTERVAL`      | PDV Tokenizer initial interval for retry a request that fail with 429 status code                                               |                          200                           |
+| `PDV_TOKENIZER_MULTIPLIER`            | PDV Tokenizer interval multiplier for subsequent request retry                                                                  |                          2.0                           |
+| `PDV_TOKENIZER_RANDOMIZATION_FACTOR`  | PDV Tokenizer randomization factor for interval retry calculation                                                               |                          0.6                           |
+| `PDV_TOKENIZER_MAX_RETRIES`           | PDV Tokenizer max request retry                                                                                                 |                           3                            |
+| `TOKENIZER_APIM_HEADER_KEY`           | Tokenizer APIM header key                                                                                                       |                       x-api-key                        |
+| `MAX_DATE_DIFF_MILLIS`                | Difference in millis between the current time and the date from witch the receipts will be fetched in massive recover operation |                        360000                          |
+
+> to doc details about AZ fn config
+> see [here](https://stackoverflow.com/questions/62669672/azure-functions-what-is-the-purpose-of-having-host-json-and-local-settings-jso)
+
+
+#### Run the project
 
 `mvn clean package`
 
 `mvn azure-functions:run`
 
 ### Test
-`curl http://localhost:7071/example` 
+
+`curl http://localhost:8080/info`
 
 ---
 
+## Develop Locally 💻
 
-## TODO
-Once cloned the repo, you should:
-- to deploy on standard Azure service:
-  - rename `deploy-pipelines-standard.yml` to `deploy-pipelines.yml`
-  - remove `helm` folder
-- to deploy on Kubernetes:
-  - rename `deploy-pipelines-aks.yml` to `deploy-pipelines.yml`
-  - customize `helm` configuration
-- configure the following GitHub action in `.github` folder: 
-  - `deploy.yml`
-  - `sonar_analysis.yml`
+### Prerequisites
 
-Configure the SonarCloud project :point_right: [guide](https://pagopa.atlassian.net/wiki/spaces/DEVOPS/pages/147193860/SonarCloud+experimental).
+- git
+- maven
+- jdk-17
+
+### Testing 🧪
+
+#### Unit testing
+
+To run the **Junit** tests:
+
+`mvn clean verify`
+
+#### Integration testing
+
+#### Performance testing
+
+---
+
+## Contributors 👥
+
+Made with ❤️ by PagoPa S.p.A.
+
+### Maintainers
+
+See `CODEOWNERS` file

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pagopa_pagopa-receipt-pdf-helpdesk&metric=alert_status)](https://sonarcloud.io/dashboard?id=pagopa_pagopa-receipt-pdf-helpdesk)
 
 Java Azure Functions that exposed the following recover APIs:
+- ReceiptToReviewed
 - RecoverFailedReceipt
 - RecoverNotNotifiedReceipt
 
@@ -73,30 +74,31 @@ On terminal type:
 then replace env variables with correct values
 (if there is NO default value, the variable HAS to be defined)
 
-| VARIABLE                              | USAGE                                                                                                                           |                     DEFAULT VALUE                      |
-|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------:|
-| `RECEIPT_QUEUE_CONN_STRING`           | Connection string to the Receipt Queue                                                                                          |                                                        |
-| `RECEIPT_QUEUE_TOPIC`                 | Topic name of the Receipt Queue                                                                                                 |                                                        |
-| `COSMOS_BIZ_EVENT_CONN_STRING`        | Connection string to the BizEvent CosmosDB                                                                                      |                                                        |
-| `COSMOS_BIZ_EVENT_SERVICE_ENDPOINT`   | Endpoint to the BizEvent CosmosDB                                                                                               |                                                        |
-| `COSMOS_BIZ_EVENT_DB_NAME`            | Database name of the BizEvent database in CosmosDB                                                                              |                                                        |
-| `COSMOS_BIZ_EVENT_CONTAINER_NAME`     | Container name of the BizEvent container in CosmosDB                                                                            |                                                        |
-| `COSMOS_RECEIPTS_CONN_STRING`         | Connection string to the Receipt CosmosDB                                                                                       |                                                        |
-| `COSMOS_RECEIPT_SERVICE_ENDPOINT`     | Endpoint to the Receipt CosmosDB                                                                                                |                                                        |
-| `COSMOS_RECEIPT_KEY`                  | Key to the Receipt CosmosDB                                                                                                     |                                                        |
-| `COSMOS_RECEIPT_DB_NAME`              | Database name of the Receipt database in CosmosDB                                                                               |                                                        |
-| `COSMOS_RECEIPT_CONTAINER_NAME`       | Container name of the Receipt container in CosmosDB                                                                             |                                                        |
-| `PDV_TOKENIZER_BASE_PATH`             | PDV Tokenizer API base path                                                                                                     | "https://api.uat.tokenizer.pdv.pagopa.it/tokenizer/v1" |
-| `PDV_TOKENIZER_SEARCH_TOKEN_ENDPOINT` | PDV Tokenizer API search token endpoint                                                                                         |                    "/tokens/search"                    |
-| `PDV_TOKENIZER_FIND_PII_ENDPOINT`     | PDV Tokenizer API find pii endpoint                                                                                             |                    "/tokens/%s/pii"                    |
-| `PDV_TOKENIZER_CREATE_TOKEN_ENDPOINT` | PDV Tokenizer API create token endpoint                                                                                         |                       "/tokens"                        |
-| `PDV_TOKENIZER_SUBSCRIPTION_KEY`      | API azure ocp apim subscription key                                                                                             |                                                        |
-| `PDV_TOKENIZER_INITIAL_INTERVAL`      | PDV Tokenizer initial interval for retry a request that fail with 429 status code                                               |                          200                           |
-| `PDV_TOKENIZER_MULTIPLIER`            | PDV Tokenizer interval multiplier for subsequent request retry                                                                  |                          2.0                           |
-| `PDV_TOKENIZER_RANDOMIZATION_FACTOR`  | PDV Tokenizer randomization factor for interval retry calculation                                                               |                          0.6                           |
-| `PDV_TOKENIZER_MAX_RETRIES`           | PDV Tokenizer max request retry                                                                                                 |                           3                            |
-| `TOKENIZER_APIM_HEADER_KEY`           | Tokenizer APIM header key                                                                                                       |                       x-api-key                        |
-| `MAX_DATE_DIFF_MILLIS`                | Difference in millis between the current time and the date from witch the receipts will be fetched in massive recover operation |                        360000                          |
+| VARIABLE                               | USAGE                                                                                                                           |                     DEFAULT VALUE                      |
+|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------:|
+| `RECEIPT_QUEUE_CONN_STRING`            | Connection string to the Receipt Queue                                                                                          |                                                        |
+| `RECEIPT_QUEUE_TOPIC`                  | Topic name of the Receipt Queue                                                                                                 |                                                        |
+| `COSMOS_BIZ_EVENT_CONN_STRING`         | Connection string to the BizEvent CosmosDB                                                                                      |                                                        |
+| `COSMOS_BIZ_EVENT_SERVICE_ENDPOINT`    | Endpoint to the BizEvent CosmosDB                                                                                               |                                                        |
+| `COSMOS_BIZ_EVENT_DB_NAME`             | Database name of the BizEvent database in CosmosDB                                                                              |                                                        |
+| `COSMOS_BIZ_EVENT_CONTAINER_NAME`      | Container name of the BizEvent container in CosmosDB                                                                            |                                                        |
+| `COSMOS_RECEIPTS_CONN_STRING`          | Connection string to the Receipt CosmosDB                                                                                       |                                                        |
+| `COSMOS_RECEIPT_SERVICE_ENDPOINT`      | Endpoint to the Receipt CosmosDB                                                                                                |                                                        |
+| `COSMOS_RECEIPT_KEY`                   | Key to the Receipt CosmosDB                                                                                                     |                                                        |
+| `COSMOS_RECEIPT_DB_NAME`               | Database name of the Receipt database in CosmosDB                                                                               |                                                        |
+| `COSMOS_RECEIPT_CONTAINER_NAME`        | Container name of the Receipt container in CosmosDB                                                                             |                                                        |
+| `COSMOS_RECEIPT_ERROR_CONTAINER_NAME`  | Container name of the Receipt-message-error container in CosmosDB                                                               |                                                        |
+| `PDV_TOKENIZER_BASE_PATH`              | PDV Tokenizer API base path                                                                                                     | "https://api.uat.tokenizer.pdv.pagopa.it/tokenizer/v1" |
+| `PDV_TOKENIZER_SEARCH_TOKEN_ENDPOINT`  | PDV Tokenizer API search token endpoint                                                                                         |                    "/tokens/search"                    |
+| `PDV_TOKENIZER_FIND_PII_ENDPOINT`      | PDV Tokenizer API find pii endpoint                                                                                             |                    "/tokens/%s/pii"                    |
+| `PDV_TOKENIZER_CREATE_TOKEN_ENDPOINT`  | PDV Tokenizer API create token endpoint                                                                                         |                       "/tokens"                        |
+| `PDV_TOKENIZER_SUBSCRIPTION_KEY`       | API azure ocp apim subscription key                                                                                             |                                                        |
+| `PDV_TOKENIZER_INITIAL_INTERVAL`       | PDV Tokenizer initial interval for retry a request that fail with 429 status code                                               |                          200                           |
+| `PDV_TOKENIZER_MULTIPLIER`             | PDV Tokenizer interval multiplier for subsequent request retry                                                                  |                          2.0                           |
+| `PDV_TOKENIZER_RANDOMIZATION_FACTOR`   | PDV Tokenizer randomization factor for interval retry calculation                                                               |                          0.6                           |
+| `PDV_TOKENIZER_MAX_RETRIES`            | PDV Tokenizer max request retry                                                                                                 |                           3                            |
+| `TOKENIZER_APIM_HEADER_KEY`            | Tokenizer APIM header key                                                                                                       |                       x-api-key                        |
+| `MAX_DATE_DIFF_MILLIS`                 | Difference in millis between the current time and the date from witch the receipts will be fetched in massive recover operation |                        360000                          |
 
 > to doc details about AZ fn config
 > see [here](https://stackoverflow.com/questions/62669672/azure-functions-what-is-the-purpose-of-having-host-json-and-local-settings-jso)

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -233,6 +233,148 @@
           }
         }
       ]
+    },
+    "/recoverNotNotified": {
+      "put": {
+        "tags": [
+          "Receipts REST APIs"
+        ],
+        "summary": "Recover a receipt, or group of, in IO_ERROR_TO_NOTIFY or GENERATED status",
+        "operationId": "recoverNotNotified",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotNotifiedRecoveryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Succesfull Calls.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request invalid input.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Wrong or missing function key.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Requested receipt not found.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The requested receipts is not in a status that can be elaborated.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
     }
   },
   "components": {
@@ -257,6 +399,24 @@
           "eventId": {
             "type": "string",
             "description": "Id of the event to start recovering (optional)"
+          }
+        }
+      },
+      "NotNotifiedRecoveryRequest": {
+        "type": "object",
+        "description": "The request body for recoverNotNotified API, at least one of generatedStatus or ioErrorToNotifyStatus must be true. The field eventId when not provided enable the massive operation",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "description": "Id of the event to start recovering (optional)"
+          },
+          "generatedStatus": {
+            "type": "boolean",
+            "description": "True to recover the receipts in GENERATED status, false otherwise"
+          },
+          "ioErrorToNotifyStatus": {
+            "type": "boolean",
+            "description": "True to recover the receipts in IO_ERROR_TO_NOTIFY status, false otherwise"
           }
         }
       },

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceipt.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceipt.java
@@ -163,7 +163,7 @@ public class RecoverFailedReceipt {
                     bizEventToReceiptService.handleSendMessageToQueue(bizEvent, receipt);
                     if(receipt.getStatus() != ReceiptStatusType.NOT_QUEUE_SENT){
                         receipt.setStatus(ReceiptStatusType.INSERTED);
-                        receipt.setInserted_at(System.currentTimeMillis());
+                        receipt.setInsertedAt(System.currentTimeMillis());
                         receipt.setReasonErr(null);
                         receipt.setReasonErrPayer(null);
                     }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceipt.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceipt.java
@@ -1,0 +1,185 @@
+package it.gov.pagopa.receipt.pdf.helpdesk;
+
+import com.azure.cosmos.models.FeedResponse;
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.OutputBinding;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.CosmosDBOutput;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+import it.gov.pagopa.receipt.pdf.helpdesk.client.ReceiptCosmosClient;
+import it.gov.pagopa.receipt.pdf.helpdesk.client.impl.ReceiptCosmosClientImpl;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
+import it.gov.pagopa.receipt.pdf.helpdesk.exception.ReceiptNotFoundException;
+import it.gov.pagopa.receipt.pdf.helpdesk.model.IONotifyErrorRecoveryRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Azure Functions with HTTP Trigger.
+ */
+public class RecoverNotNotifiedReceipt {
+
+    private final Logger logger = LoggerFactory.getLogger(RecoverNotNotifiedReceipt.class);
+
+    private final ReceiptCosmosClient receiptCosmosClient;
+
+    public RecoverNotNotifiedReceipt() {
+        this.receiptCosmosClient = ReceiptCosmosClientImpl.getInstance();
+    }
+
+    RecoverNotNotifiedReceipt(ReceiptCosmosClient receiptCosmosClient) {
+        this.receiptCosmosClient = receiptCosmosClient;
+    }
+
+    /**
+     * This function will be invoked when a Http Trigger occurs.
+     * <p>
+     * It recovers the receipt with failed notification ({@link ReceiptStatusType#IO_ERROR_TO_NOTIFY}) or notification
+     * not triggered ({@link ReceiptStatusType#GENERATED} by clearing the errors and update the status to the
+     * previous step ({@link ReceiptStatusType#GENERATED}).
+     * <p>
+     * If invoked with a specific eventId it restore the associated receipt, otherwise it restore all receipt with status
+     * {@link ReceiptStatusType#IO_ERROR_TO_NOTIFY}.
+     *
+     * @return response with {@link HttpStatus#OK} if the notification succeeded
+     */
+    @FunctionName("RecoverNotNotifiedReceipt")
+    public HttpResponseMessage run(
+            @HttpTrigger(name = "RecoverNotNotifiedTrigger",
+                    methods = {HttpMethod.PUT},
+                    route = "recoverNotNotified",
+                    authLevel = AuthorizationLevel.FUNCTION)
+            HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request,
+            @CosmosDBOutput(
+                    name = "ReceiptDatastore",
+                    databaseName = "db",
+                    collectionName = "receipts",
+                    connectionStringSetting = "COSMOS_RECEIPTS_CONN_STRING")
+            OutputBinding<List<Receipt>> documentReceipts,
+            final ExecutionContext context) {
+        logger.info("[{}] function called at {}", context.getFunctionName(), LocalDateTime.now());
+
+        Optional<IONotifyErrorRecoveryRequest> recoveryRequestOptional = request.getBody();
+        if (recoveryRequestOptional.isEmpty()) {
+            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a valid body").build();
+        }
+        IONotifyErrorRecoveryRequest recoveryRequest = recoveryRequestOptional.get();
+
+        List<ReceiptStatusType> statusToRestore = getStatusToRestore(recoveryRequest);
+        if (statusToRestore.isEmpty()) {
+            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please select at least one status to recover").build();
+        }
+
+        String eventId = recoveryRequest.getEventId();
+        if (eventId != null) {
+            Receipt receipt;
+            try {
+                receipt = getReceipt(eventId);
+            } catch (ReceiptNotFoundException e) {
+                String responseMsg = String.format("Unable to retrieve the receipt with eventId %s", eventId);
+                logger.error("[{}] {}", context.getFunctionName(), responseMsg, e);
+                return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body(responseMsg).build();
+            }
+
+            if (!statusToRestore.contains(receipt.getStatus())) {
+                String responseMsg = String.format("The requested receipt with eventId %s is not in the expected status",
+                        receipt.getEventId());
+                return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body(responseMsg).build();
+            }
+
+            Receipt restoredReceipt = restoreReceipt(receipt);
+
+            documentReceipts.setValue(Collections.singletonList(restoredReceipt));
+            String responseMsg = String.format("Receipt with id %s and eventId %s restored int status %s with success",
+                    receipt.getId(), receipt.getEventId(), ReceiptStatusType.GENERATED);
+            return request.createResponseBuilder(HttpStatus.OK).body(responseMsg).build();
+        }
+
+        List<Receipt> receiptList = receiptMassiveRestore(recoveryRequest);
+        if (receiptList.isEmpty()) {
+            return request.createResponseBuilder(HttpStatus.OK).body("No receipts restored").build();
+        }
+
+        documentReceipts.setValue(receiptList);
+        String msg = String.format("Restored %s receipt with success", receiptList.size());
+        return request.createResponseBuilder(HttpStatus.OK).body(msg).build();
+    }
+
+    private List<ReceiptStatusType> getStatusToRestore(IONotifyErrorRecoveryRequest recoveryRequest) {
+        List<ReceiptStatusType> statusToRestore = new ArrayList<>();
+        if (recoveryRequest.isGeneratedStatus()) {
+            statusToRestore.add(ReceiptStatusType.GENERATED);
+        }
+        if (recoveryRequest.isIoErrorToNotifyStatus()) {
+            statusToRestore.add(ReceiptStatusType.IO_ERROR_TO_NOTIFY);
+        }
+        return statusToRestore;
+    }
+
+    private List<Receipt> receiptMassiveRestore(IONotifyErrorRecoveryRequest recoveryRequest) {
+        List<Receipt> receiptList = new ArrayList<>();
+        String continuationToken = null;
+        do {
+            Iterable<FeedResponse<Receipt>> feedResponseIterator =
+                    receiptCosmosClient
+                            .getNotNotifiedReceiptDocuments(
+                                    continuationToken,
+                                    100,
+                                    recoveryRequest.isIoErrorToNotifyStatus(),
+                                    recoveryRequest.isGeneratedStatus()
+                            );
+
+            for (FeedResponse<Receipt> page : feedResponseIterator) {
+                for (Receipt receipt : page.getResults()) {
+                    Receipt restoredReceipt = restoreReceipt(receipt);
+                    receiptList.add(restoredReceipt);
+                }
+                continuationToken = page.getContinuationToken();
+            }
+        } while (continuationToken != null);
+        return receiptList;
+    }
+
+    private Receipt restoreReceipt(Receipt receipt) {
+        receipt.setStatus(ReceiptStatusType.GENERATED);
+        receipt.setNotificationNumRetry(0);
+        receipt.setNotifiedAt(0);
+
+        if (receipt.getReasonErr() != null) {
+            receipt.setReasonErr(null);
+        }
+        if (receipt.getReasonErrPayer() != null) {
+            receipt.setReasonErrPayer(null);
+        }
+        return receipt;
+    }
+
+    //Retrieve receipt from CosmosDB
+    private Receipt getReceipt(String eventId) throws ReceiptNotFoundException {
+        Receipt receipt;
+        try {
+            receipt = receiptCosmosClient.getReceiptDocument(eventId);
+        } catch (ReceiptNotFoundException e) {
+            String errorMsg = String.format("Receipt not found with the biz-event id %s", eventId);
+            throw new ReceiptNotFoundException(errorMsg, e);
+        }
+
+        if (receipt == null) {
+            String errorMsg = String.format("Receipt retrieved with the biz-event id %s is null", eventId);
+            throw new ReceiptNotFoundException(errorMsg);
+        }
+        return receipt;
+    }
+}

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/client/ReceiptCosmosClient.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/client/ReceiptCosmosClient.java
@@ -4,11 +4,12 @@ import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.FeedResponse;
 import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.ReceiptError;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
 import it.gov.pagopa.receipt.pdf.helpdesk.exception.ReceiptNotFoundException;
 
 public interface ReceiptCosmosClient {
 
-    Receipt getReceiptDocument(String receiptId) throws ReceiptNotFoundException;
+    Receipt getReceiptDocument(String eventId) throws ReceiptNotFoundException;
 
     Iterable<FeedResponse<Receipt>> getFailedReceiptDocuments(String continuationToken, Integer pageSize);
 
@@ -17,4 +18,21 @@ public interface ReceiptCosmosClient {
     ReceiptError getReceiptError(String bizEventId) throws  ReceiptNotFoundException;
 
     Iterable<FeedResponse<ReceiptError>> getToReviewReceiptsError(String continuationToken, Integer pageSize);
+
+    /**
+     * Retrieve the receipt documents with status {@link ReceiptStatusType#IO_ERROR_TO_NOTIFY}
+     * or {@link ReceiptStatusType#GENERATED} from Cosmos database
+     *
+     * @param continuationToken Paged query continuation token
+     * @param pageSize the page size
+     * @param ioErrorToNotifyStatus true if the receipts must be in {@link ReceiptStatusType#IO_ERROR_TO_NOTIFY} status, false otherwise
+     * @param generatedStatus true if the receipts must be in {@link ReceiptStatusType#GENERATED} status, false otherwise
+     * @return receipt documents
+     */
+    Iterable<FeedResponse<Receipt>> getNotNotifiedReceiptDocuments(
+            String continuationToken,
+            Integer pageSize,
+            boolean ioErrorToNotifyStatus,
+            boolean generatedStatus
+    );
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/client/impl/ReceiptCosmosClientImpl.java
@@ -50,7 +50,6 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
         if (instance == null) {
             instance = new ReceiptCosmosClientImpl();
         }
-
         return instance;
     }
 
@@ -63,7 +62,6 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      */
     public Receipt getReceiptDocument(String eventId) throws ReceiptNotFoundException {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
 
         //Build query
@@ -78,7 +76,6 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
         } else {
             throw new ReceiptNotFoundException("Document not found in the defined container");
         }
-
     }
 
     /**
@@ -90,7 +87,6 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     @Override
     public Iterable<FeedResponse<Receipt>> getFailedReceiptDocuments(String continuationToken, Integer pageSize)  {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
 
         //Build query
@@ -102,7 +98,6 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
         return cosmosContainer
                 .queryItems(query, new CosmosQueryRequestOptions(), Receipt.class)
                 .iterableByPage(continuationToken,pageSize);
-
     }
 
     /**
@@ -114,7 +109,6 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     @Override
     public CosmosItemResponse<Receipt> saveReceipts(Receipt receipt)  {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
 
         return cosmosContainer.createItem(receipt);

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/CartItem.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/CartItem.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +9,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CartItem {
     private String subject;
     private String payeeName;

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/EventData.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/EventData.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +11,8 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class EventData {
     private String payerFiscalCode;
     private String debtorFiscalCode;

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/IOMessageData.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/IOMessageData.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +9,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class IOMessageData {
     private String idMessageDebtor;
     private String idMessagePayer;

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/ReasonError.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/ReasonError.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +10,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ReasonError {
     private int code;
     private String message;

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/Receipt.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/Receipt.java
@@ -1,6 +1,9 @@
 package it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,6 +11,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Receipt {
 
     private String eventId;
@@ -21,8 +26,12 @@ public class Receipt {
     private int numRetry;
     private ReasonError reasonErr;
     private ReasonError reasonErrPayer;
-    private long inserted_at;
-    private long generated_at;
-    private long notified_at;
+    private int notificationNumRetry;
+    @JsonProperty("inserted_at")
+    private long insertedAt;
+    @JsonProperty("generated_at")
+    private long generatedAt;
+    @JsonProperty("notified_at")
+    private long notifiedAt;
 
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/ReceiptMetadata.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/entity/receipt/ReceiptMetadata.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +9,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class ReceiptMetadata {
 
     private String name;

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/model/IONotifyErrorRecoveryRequest.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/model/IONotifyErrorRecoveryRequest.java
@@ -1,0 +1,16 @@
+package it.gov.pagopa.receipt.pdf.helpdesk.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class IONotifyErrorRecoveryRequest {
+
+    private String eventId;
+    private boolean generatedStatus;
+    private boolean ioErrorToNotifyStatus;
+
+}

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/model/NotNotifiedRecoveryRequest.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/model/NotNotifiedRecoveryRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class IONotifyErrorRecoveryRequest {
+public class NotNotifiedRecoveryRequest {
 
     private String eventId;
     private boolean generatedStatus;

--- a/src/test/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceiptTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceiptTest.java
@@ -1,0 +1,422 @@
+package it.gov.pagopa.receipt.pdf.helpdesk;
+
+import com.azure.cosmos.models.FeedResponse;
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.OutputBinding;
+import it.gov.pagopa.receipt.pdf.helpdesk.client.ReceiptCosmosClient;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.ReasonError;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
+import it.gov.pagopa.receipt.pdf.helpdesk.exception.ReceiptNotFoundException;
+import it.gov.pagopa.receipt.pdf.helpdesk.model.IONotifyErrorRecoveryRequest;
+import it.gov.pagopa.receipt.pdf.helpdesk.util.HttpResponseMessageMock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecoverNotNotifiedReceiptTest {
+
+    private static final String EVENT_ID = "eventId";
+
+    private final ExecutionContext executionContextMock = mock(ExecutionContext.class);
+
+    @Mock
+    private ReceiptCosmosClient receiptCosmosClientMock;
+
+    @Spy
+    OutputBinding<List<Receipt>> documentReceipts;
+
+    @Captor
+    private ArgumentCaptor<List<Receipt>> receiptCaptor;
+
+    private RecoverNotNotifiedReceipt sut;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void openMocks() {
+        closeable = MockitoAnnotations.openMocks(this);
+        sut = spy(new RecoverNotNotifiedReceipt(receiptCosmosClientMock));
+    }
+
+    @AfterEach
+    public void releaseMocks() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    void recoverNotNotifiedReceiptWithEventIdSuccess() throws ReceiptNotFoundException {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        Receipt receipt = buildReceipt();
+        when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenReturn(receipt);
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts).setValue(receiptCaptor.capture());
+
+        assertEquals(1, receiptCaptor.getValue().size());
+        Receipt captured = receiptCaptor.getValue().get(0);
+        assertEquals(ReceiptStatusType.GENERATED, captured.getStatus());
+        assertEquals(EVENT_ID, captured.getEventId());
+        assertEquals(0, captured.getNotificationNumRetry());
+        assertNull(captured.getReasonErr());
+        assertNull(captured.getReasonErrPayer());
+    }
+
+    @Test
+    void recoverNotNotifiedReceiptWithoutEventIdSuccess() {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(null, false, true);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        FeedResponse feedResponseMock = mock(FeedResponse.class);
+        List<Receipt> receiptList = getReceiptList();
+        when(feedResponseMock.getResults()).thenReturn(receiptList);
+        when(receiptCosmosClientMock.getNotNotifiedReceiptDocuments(any(), any(), anyBoolean(), anyBoolean()))
+                .thenReturn(Collections.singletonList(feedResponseMock));
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts).setValue(receiptCaptor.capture());
+
+        assertEquals(receiptList.size(), receiptCaptor.getValue().size());
+        Receipt captured1 = receiptCaptor.getValue().get(0);
+        assertEquals(ReceiptStatusType.GENERATED, captured1.getStatus());
+        assertEquals(EVENT_ID, captured1.getEventId());
+        assertEquals(0, captured1.getNotificationNumRetry());
+        assertNull(captured1.getReasonErr());
+        assertNull(captured1.getReasonErrPayer());
+        Receipt captured2 = receiptCaptor.getValue().get(0);
+        assertEquals(ReceiptStatusType.GENERATED, captured2.getStatus());
+        assertEquals(EVENT_ID, captured2.getEventId());
+        assertEquals(0, captured2.getNotificationNumRetry());
+        assertNull(captured2.getReasonErr());
+        assertNull(captured2.getReasonErrPayer());
+    }
+
+    @Test
+    void recoverNotNotifiedReceiptWithoutEventIdSuccessWithNoReceiptUpdated() {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(null, false, true);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        FeedResponse feedResponseMock = mock(FeedResponse.class);
+        when(feedResponseMock.getResults()).thenReturn(Collections.emptyList());
+        when(receiptCosmosClientMock.getNotNotifiedReceiptDocuments(any(), any(), anyBoolean(), anyBoolean()))
+                .thenReturn(Collections.singletonList(feedResponseMock));
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    void recoverReceiptFailForEmptyBody() {
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.empty());
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    void recoverReceiptFailForInvalidInputParams() {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, false);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    void recoverReceiptFailReceiptNotFound() throws ReceiptNotFoundException {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenThrow(ReceiptNotFoundException.class);
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    void recoverReceiptFailReceiptFoundIsNull() throws ReceiptNotFoundException {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenReturn(null);
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    void recoverReceiptFailReceiptInGeneratedButOnlyIOErrorToNotify() throws ReceiptNotFoundException {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        Receipt receipt = new Receipt();
+        receipt.setStatus(ReceiptStatusType.GENERATED);
+        when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenReturn(receipt);
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    void recoverReceiptFailReceiptInIOErrorToNotifyButOnlyGenerated() throws ReceiptNotFoundException {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, true, false);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        Receipt receipt = new Receipt();
+        receipt.setStatus(ReceiptStatusType.IO_ERROR_TO_NOTIFY);
+        when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenReturn(receipt);
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    void recoverReceiptFailReceiptInInsertedButOnlyGenerated() throws ReceiptNotFoundException {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, true, false);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        Receipt receipt = new Receipt();
+        receipt.setStatus(ReceiptStatusType.INSERTED);
+        when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenReturn(receipt);
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    @Test
+    void recoverReceiptFailReceiptInInsertedButOnlyIOErrorToNotify() throws ReceiptNotFoundException {
+        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
+
+        Receipt receipt = new Receipt();
+        receipt.setStatus(ReceiptStatusType.INSERTED);
+        when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenReturn(receipt);
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(request).createResponseBuilder(any(HttpStatus.class));
+
+        // test execution
+        HttpResponseMessage response = sut.run(request, documentReceipts, executionContextMock);
+
+        // test assertion
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertNotNull(response.getBody());
+
+        verify(documentReceipts, never()).setValue(receiptCaptor.capture());
+    }
+
+    private Receipt buildReceipt() {
+        return Receipt.builder()
+                .eventId(EVENT_ID)
+                .status(ReceiptStatusType.IO_ERROR_TO_NOTIFY)
+                .reasonErr(ReasonError.builder()
+                        .code(500)
+                        .message("error message")
+                        .build())
+                .reasonErrPayer(ReasonError.builder()
+                        .code(500)
+                        .message("error message")
+                        .build())
+                .numRetry(0)
+                .notificationNumRetry(6)
+                .insertedAt(0)
+                .generatedAt(0)
+                .notifiedAt(0)
+                .build();
+    }
+
+    private List<Receipt> getReceiptList() {
+        List<Receipt> receiptList = new ArrayList<>();
+        Receipt receipt1 = buildReceipt();
+        Receipt receipt2 = buildReceipt();
+        receiptList.add(receipt1);
+        receiptList.add(receipt2);
+        return receiptList;
+    }
+}

--- a/src/test/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceiptTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceiptTest.java
@@ -11,7 +11,7 @@ import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.ReasonError;
 import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
 import it.gov.pagopa.receipt.pdf.helpdesk.exception.ReceiptNotFoundException;
-import it.gov.pagopa.receipt.pdf.helpdesk.model.IONotifyErrorRecoveryRequest;
+import it.gov.pagopa.receipt.pdf.helpdesk.model.NotNotifiedRecoveryRequest;
 import it.gov.pagopa.receipt.pdf.helpdesk.util.HttpResponseMessageMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,10 +75,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverNotNotifiedReceiptWithEventIdSuccess() throws ReceiptNotFoundException {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(EVENT_ID, false, true);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         Receipt receipt = buildReceipt();
@@ -110,10 +110,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverNotNotifiedReceiptWithoutEventIdSuccess() {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(null, false, true);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(null, false, true);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         FeedResponse feedResponseMock = mock(FeedResponse.class);
@@ -154,10 +154,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverNotNotifiedReceiptWithoutEventIdSuccessWithNoReceiptUpdated() {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(null, false, true);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(null, false, true);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         FeedResponse feedResponseMock = mock(FeedResponse.class);
@@ -184,7 +184,7 @@ class RecoverNotNotifiedReceiptTest {
     @Test
     void recoverReceiptFailForEmptyBody() {
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.empty());
 
         doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
@@ -205,10 +205,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverReceiptFailForInvalidInputParams() {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, false);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(EVENT_ID, false, false);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
@@ -229,10 +229,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverReceiptFailReceiptNotFound() throws ReceiptNotFoundException {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(EVENT_ID, false, true);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenThrow(ReceiptNotFoundException.class);
@@ -247,7 +247,7 @@ class RecoverNotNotifiedReceiptTest {
 
         // test assertion
         assertNotNull(response);
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatus());
         assertNotNull(response.getBody());
 
         verify(documentReceipts, never()).setValue(receiptCaptor.capture());
@@ -255,10 +255,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverReceiptFailReceiptFoundIsNull() throws ReceiptNotFoundException {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(EVENT_ID, false, true);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         when(receiptCosmosClientMock.getReceiptDocument(EVENT_ID)).thenReturn(null);
@@ -273,7 +273,7 @@ class RecoverNotNotifiedReceiptTest {
 
         // test assertion
         assertNotNull(response);
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatus());
         assertNotNull(response.getBody());
 
         verify(documentReceipts, never()).setValue(receiptCaptor.capture());
@@ -281,10 +281,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverReceiptFailReceiptInGeneratedButOnlyIOErrorToNotify() throws ReceiptNotFoundException {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(EVENT_ID, false, true);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         Receipt receipt = new Receipt();
@@ -301,7 +301,7 @@ class RecoverNotNotifiedReceiptTest {
 
         // test assertion
         assertNotNull(response);
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatus());
         assertNotNull(response.getBody());
 
         verify(documentReceipts, never()).setValue(receiptCaptor.capture());
@@ -309,10 +309,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverReceiptFailReceiptInIOErrorToNotifyButOnlyGenerated() throws ReceiptNotFoundException {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, true, false);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(EVENT_ID, true, false);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         Receipt receipt = new Receipt();
@@ -329,7 +329,7 @@ class RecoverNotNotifiedReceiptTest {
 
         // test assertion
         assertNotNull(response);
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatus());
         assertNotNull(response.getBody());
 
         verify(documentReceipts, never()).setValue(receiptCaptor.capture());
@@ -337,10 +337,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverReceiptFailReceiptInInsertedButOnlyGenerated() throws ReceiptNotFoundException {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, true, false);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(EVENT_ID, true, false);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         Receipt receipt = new Receipt();
@@ -357,7 +357,7 @@ class RecoverNotNotifiedReceiptTest {
 
         // test assertion
         assertNotNull(response);
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatus());
         assertNotNull(response.getBody());
 
         verify(documentReceipts, never()).setValue(receiptCaptor.capture());
@@ -365,10 +365,10 @@ class RecoverNotNotifiedReceiptTest {
 
     @Test
     void recoverReceiptFailReceiptInInsertedButOnlyIOErrorToNotify() throws ReceiptNotFoundException {
-        IONotifyErrorRecoveryRequest recoveryRequest = new IONotifyErrorRecoveryRequest(EVENT_ID, false, true);
+        NotNotifiedRecoveryRequest recoveryRequest = new NotNotifiedRecoveryRequest(EVENT_ID, false, true);
 
         @SuppressWarnings("unchecked")
-        HttpRequestMessage<Optional<IONotifyErrorRecoveryRequest>> request = mock(HttpRequestMessage.class);
+        HttpRequestMessage<Optional<NotNotifiedRecoveryRequest>> request = mock(HttpRequestMessage.class);
         when(request.getBody()).thenReturn(Optional.of(recoveryRequest));
 
         Receipt receipt = new Receipt();
@@ -385,7 +385,7 @@ class RecoverNotNotifiedReceiptTest {
 
         // test assertion
         assertNotNull(response);
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatus());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatus());
         assertNotNull(response.getBody());
 
         verify(documentReceipts, never()).setValue(receiptCaptor.capture());

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added new RecoverNotNotifiedReceipt function
- updated unit test
- updated openapi.json
- updated README

<!--- Describe your changes in detail -->

#### Motivation and Context
Add recover API for receipts in IO_ERROR_TO_NOTIFY and GENERATED status
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.