### PR TITLE
[PRDP-267] feat: Add timer trigger function for recovering failed receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ then replace env variables with correct values
 | `PDV_TOKENIZER_MAX_RETRIES`           | PDV Tokenizer max request retry                                                                                                      |                           3                            |
 | `TOKENIZER_APIM_HEADER_KEY`           | Tokenizer APIM header key                                                                                                            |                       x-api-key                        |
 | `MAX_DATE_DIFF_MILLIS`                | Difference in millis between the current time and the date from witch the<br/> receipts will be fetched in massive recover operation |                         360000                         |
+| `RECOVER_FAILED_CRON`                 | CRON expression for timer trigger function that recover failed receipt                                                               |                                                        |
 
 > to doc details about AZ fn config
 > see [here](https://stackoverflow.com/questions/62669672/azure-functions-what-is-the-purpose-of-having-host-json-and-local-settings-jso)

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -110,6 +110,7 @@ microservice-chart:
     MAX_DATE_DIFF_MILLIS: "360000"
     MAX_DATE_DIFF_NOTIFY_MILLIS: "360000"
     TRIGGER_NOTIFY_REC_SCHEDULE: "0 0 */6 * * *"
+    RECOVER_FAILED_CRON: "0 0 /12 * * *"
     AZURE_FUNCTIONS_MESH_JAVA_OPTS: "-javaagent:/home/site/wwwroot/jmx_prometheus_javaagent-0.19.0.jar=12345:/home/site/wwwroot/config.yaml -javaagent:/home/site/wwwroot/opentelemetry-javaagent.jar -Xmx768m -XX:+UseG1GC"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -110,6 +110,7 @@ microservice-chart:
     MAX_DATE_DIFF_MILLIS: "360000"
     MAX_DATE_DIFF_NOTIFY_MILLIS: "360000"
     TRIGGER_NOTIFY_REC_SCHEDULE: "0 0 */6 * * *"
+    RECOVER_FAILED_CRON: "0 0 /12 * * *"
     AZURE_FUNCTIONS_MESH_JAVA_OPTS: "-javaagent:/home/site/wwwroot/jmx_prometheus_javaagent-0.19.0.jar=12345:/home/site/wwwroot/config.yaml -javaagent:/home/site/wwwroot/opentelemetry-javaagent.jar -Xmx768m -XX:+UseG1GC"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -110,6 +110,7 @@ microservice-chart:
     MAX_DATE_DIFF_MILLIS: "360000"
     MAX_DATE_DIFF_NOTIFY_MILLIS: "360000"
     TRIGGER_NOTIFY_REC_SCHEDULE: "0 0 */6 * * *"
+    RECOVER_FAILED_CRON: "0 0 /12 * * *"
     AZURE_FUNCTIONS_MESH_JAVA_OPTS: "-javaagent:/home/site/wwwroot/jmx_prometheus_javaagent-0.19.0.jar=12345:/home/site/wwwroot/config.yaml -javaagent:/home/site/wwwroot/opentelemetry-javaagent.jar -Xmx768m -XX:+UseG1GC"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceipt.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceipt.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.functions.annotation.HttpTrigger;
 import it.gov.pagopa.receipt.pdf.helpdesk.client.BizEventCosmosClient;
 import it.gov.pagopa.receipt.pdf.helpdesk.client.impl.BizEventCosmosClientImpl;
 import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
 import it.gov.pagopa.receipt.pdf.helpdesk.exception.BizEventNotFoundException;
 import it.gov.pagopa.receipt.pdf.helpdesk.exception.PDVTokenizerException;
 import it.gov.pagopa.receipt.pdf.helpdesk.model.ProblemJson;
@@ -55,9 +56,16 @@ public class RecoverFailedReceipt {
     }
 
     /**
-     * This function will be invoked when a Http Trigger occurs
+     * This function will be invoked when a Http Trigger occurs.
+     * <p>
+     * It recovers the receipt with the specified biz event id that has the following status:
+     * - ({@link ReceiptStatusType#INSERTED})
+     * - ({@link ReceiptStatusType#FAILED})
+     * - ({@link ReceiptStatusType#NOT_QUEUE_SENT})
+     * <p>
+     * It creates the receipts if not exist and send on queue the event in order to proceed with the receipt generation.
      *
-     * @return response with HttpStatus.OK
+     * @return response with {@link HttpStatus#OK} if the operation succeeded
      */
     @FunctionName("RecoverFailedReceipt")
     public HttpResponseMessage run (

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptMassive.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptMassive.java
@@ -57,9 +57,16 @@ public class RecoverFailedReceiptMassive {
     }
 
     /**
-     * This function will be invoked when a Http Trigger occurs
+     * This function will be invoked when a Http Trigger occurs.
+     * <p>
+     * It recovers all the receipts with the specified status that has to be one of:
+     * - ({@link ReceiptStatusType#INSERTED})
+     * - ({@link ReceiptStatusType#FAILED})
+     * - ({@link ReceiptStatusType#NOT_QUEUE_SENT})
+     * <p>
+     * It creates the receipts if not exist and send on queue the event in order to proceed with the receipt generation.
      *
-     * @return response with HttpStatus.OK
+     * @return response with {@link HttpStatus#OK} if the operation succeeded
      */
     @FunctionName("RecoverFailedReceiptMassive")
     public HttpResponseMessage run(

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptMassive.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptMassive.java
@@ -42,7 +42,7 @@ public class RecoverFailedReceiptMassive {
     private final BizEventCosmosClient bizEventCosmosClient;
     private final ReceiptCosmosService receiptCosmosService;
 
-    public RecoverFailedReceiptMassive(){
+    public RecoverFailedReceiptMassive() {
         this.bizEventToReceiptService = new BizEventToReceiptServiceImpl();
         this.receiptCosmosService = new ReceiptCosmosServiceImpl();
         this.bizEventCosmosClient = BizEventCosmosClientImpl.getInstance();
@@ -50,7 +50,7 @@ public class RecoverFailedReceiptMassive {
 
     RecoverFailedReceiptMassive(BizEventToReceiptService bizEventToReceiptService,
                                 BizEventCosmosClient bizEventCosmosClient,
-                                ReceiptCosmosService receiptCosmosService){
+                                ReceiptCosmosService receiptCosmosService) {
         this.bizEventToReceiptService = bizEventToReceiptService;
         this.bizEventCosmosClient = bizEventCosmosClient;
         this.receiptCosmosService = receiptCosmosService;
@@ -62,7 +62,7 @@ public class RecoverFailedReceiptMassive {
      * @return response with HttpStatus.OK
      */
     @FunctionName("RecoverFailedReceiptMassive")
-    public HttpResponseMessage run (
+    public HttpResponseMessage run(
             @HttpTrigger(name = "RecoverFailedReceiptMassiveTrigger",
                     methods = {HttpMethod.POST},
                     route = "receipts/recover-failed",
@@ -127,7 +127,7 @@ public class RecoverFailedReceiptMassive {
                 }
             } while (continuationToken != null);
         } catch (NoSuchElementException e) {
-            logger.error(e.getMessage(), e);
+            logger.error("[{}] Unexpected error during recover of failed receipt", context.getFunctionName(), e);
             return request
                     .createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(ProblemJson.builder()
@@ -137,7 +137,7 @@ public class RecoverFailedReceiptMassive {
                             .build())
                     .build();
         }
-        
+
         documentdb.setValue(receiptList);
         if (errorCounter > 0) {
             String msg = String.format("Recovered %s receipts but %s encountered an error.", receiptList.size(), errorCounter);

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptMassive.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptMassive.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.receipt.pdf.helpdesk;
 
-import com.azure.cosmos.models.FeedResponse;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.HttpMethod;
 import com.microsoft.azure.functions.HttpRequestMessage;
@@ -15,6 +14,7 @@ import it.gov.pagopa.receipt.pdf.helpdesk.client.BizEventCosmosClient;
 import it.gov.pagopa.receipt.pdf.helpdesk.client.impl.BizEventCosmosClientImpl;
 import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
+import it.gov.pagopa.receipt.pdf.helpdesk.model.MassiveRecoverResult;
 import it.gov.pagopa.receipt.pdf.helpdesk.model.ProblemJson;
 import it.gov.pagopa.receipt.pdf.helpdesk.service.BizEventToReceiptService;
 import it.gov.pagopa.receipt.pdf.helpdesk.service.ReceiptCosmosService;
@@ -24,12 +24,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import static it.gov.pagopa.receipt.pdf.helpdesk.utils.BizEventToReceiptUtils.getEvent;
+import static it.gov.pagopa.receipt.pdf.helpdesk.utils.BizEventToReceiptUtils.massiveRecoverByStatus;
 
 /**
  * Azure Functions with Azure Http trigger.
@@ -111,28 +110,10 @@ public class RecoverFailedReceiptMassive {
                     .build();
         }
 
-        List<Receipt> receiptList = new ArrayList<>();
-        String continuationToken = null;
-        int errorCounter = 0;
+        MassiveRecoverResult recoverResult;
         try {
-            do {
-                Iterable<FeedResponse<Receipt>> feedResponseIterator =
-                        this.receiptCosmosService.getFailedReceiptByStatus(continuationToken, 100, statusType);
-
-                for (FeedResponse<Receipt> page : feedResponseIterator) {
-                    for (Receipt receipt : page.getResults()) {
-                        try {
-                            Receipt restored = getEvent(receipt.getEventId(), context, this.bizEventToReceiptService,
-                                    this.bizEventCosmosClient, this.receiptCosmosService, receipt, logger);
-                            receiptList.add(restored);
-                        } catch (Exception e) {
-                            logger.error(e.getMessage(), e);
-                            errorCounter++;
-                        }
-                    }
-                    continuationToken = page.getContinuationToken();
-                }
-            } while (continuationToken != null);
+            recoverResult = massiveRecoverByStatus(
+                    context, bizEventToReceiptService, bizEventCosmosClient, receiptCosmosService, logger, statusType);
         } catch (NoSuchElementException e) {
             logger.error("[{}] Unexpected error during recover of failed receipt", context.getFunctionName(), e);
             return request
@@ -144,6 +125,8 @@ public class RecoverFailedReceiptMassive {
                             .build())
                     .build();
         }
+        List<Receipt> receiptList = recoverResult.getReceiptList();
+        int errorCounter = recoverResult.getErrorCounter();
 
         documentdb.setValue(receiptList);
         if (errorCounter > 0) {

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptScheduled.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptScheduled.java
@@ -32,6 +32,8 @@ public class RecoverFailedReceiptScheduled {
 
     private final Logger logger = LoggerFactory.getLogger(RecoverFailedReceiptScheduled.class);
 
+    private final boolean isEnabled = Boolean.parseBoolean(System.getenv().getOrDefault("FAILED_AUTORECOVER_ENABLED", "true"));
+
     private final BizEventToReceiptService bizEventToReceiptService;
     private final BizEventCosmosClient bizEventCosmosClient;
     private final ReceiptCosmosService receiptCosmosService;
@@ -71,14 +73,16 @@ public class RecoverFailedReceiptScheduled {
             OutputBinding<List<Receipt>> documentdb,
             final ExecutionContext context
     ) {
-        logger.info("[{}] function called at {}", context.getFunctionName(), LocalDateTime.now());
-        List<Receipt> receiptList = new ArrayList<>();
+        if (isEnabled) {
+            logger.info("[{}] function called at {}", context.getFunctionName(), LocalDateTime.now());
+            List<Receipt> receiptList = new ArrayList<>();
 
-        receiptList.addAll(recover(context, ReceiptStatusType.INSERTED));
-        receiptList.addAll(recover(context, ReceiptStatusType.FAILED));
-        receiptList.addAll(recover(context, ReceiptStatusType.NOT_QUEUE_SENT));
+            receiptList.addAll(recover(context, ReceiptStatusType.INSERTED));
+            receiptList.addAll(recover(context, ReceiptStatusType.FAILED));
+            receiptList.addAll(recover(context, ReceiptStatusType.NOT_QUEUE_SENT));
 
-        documentdb.setValue(receiptList);
+            documentdb.setValue(receiptList);
+        }
     }
 
     private List<Receipt> recover(ExecutionContext context, ReceiptStatusType statusType) {

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptScheduled.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptScheduled.java
@@ -49,6 +49,13 @@ public class RecoverFailedReceiptScheduled {
 
     /**
      * This function will be invoked periodically according to the specified schedule.
+     * <p>
+     * It recovers all the receipts with the following status:
+     * - ({@link ReceiptStatusType#INSERTED})
+     * - ({@link ReceiptStatusType#FAILED})
+     * - ({@link ReceiptStatusType#NOT_QUEUE_SENT})
+     * <p>
+     * It creates the receipts if not exist and send on queue the event in order to proceed with the receipt generation.
      */
     @FunctionName("RecoverFailedReceiptScheduled")
     public void run(
@@ -104,7 +111,7 @@ public class RecoverFailedReceiptScheduled {
             }
         } while (continuationToken != null);
         if (errorCounter > 0) {
-            logger.error("[{}] Error recovering {} failed receipt for status {}",
+            logger.error("[{}] Error recovering {} failed receipts for status {}",
                     context.getFunctionName(), errorCounter, statusType);
         }
         return receiptList;

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptScheduled.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptScheduled.java
@@ -1,0 +1,112 @@
+package it.gov.pagopa.receipt.pdf.helpdesk;
+
+import java.time.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import com.azure.cosmos.models.FeedResponse;
+import com.microsoft.azure.functions.annotation.*;
+import com.microsoft.azure.functions.*;
+import it.gov.pagopa.receipt.pdf.helpdesk.client.BizEventCosmosClient;
+import it.gov.pagopa.receipt.pdf.helpdesk.client.impl.BizEventCosmosClientImpl;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
+import it.gov.pagopa.receipt.pdf.helpdesk.service.BizEventToReceiptService;
+import it.gov.pagopa.receipt.pdf.helpdesk.service.ReceiptCosmosService;
+import it.gov.pagopa.receipt.pdf.helpdesk.service.impl.BizEventToReceiptServiceImpl;
+import it.gov.pagopa.receipt.pdf.helpdesk.service.impl.ReceiptCosmosServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static it.gov.pagopa.receipt.pdf.helpdesk.utils.BizEventToReceiptUtils.getEvent;
+
+/**
+ * Azure Functions with Timer trigger.
+ */
+public class RecoverFailedReceiptScheduled {
+
+    private final Logger logger = LoggerFactory.getLogger(RecoverFailedReceiptScheduled.class);
+
+    private final BizEventToReceiptService bizEventToReceiptService;
+    private final BizEventCosmosClient bizEventCosmosClient;
+    private final ReceiptCosmosService receiptCosmosService;
+
+    public RecoverFailedReceiptScheduled() {
+        this.bizEventToReceiptService = new BizEventToReceiptServiceImpl();
+        this.receiptCosmosService = new ReceiptCosmosServiceImpl();
+        this.bizEventCosmosClient = BizEventCosmosClientImpl.getInstance();
+    }
+
+    RecoverFailedReceiptScheduled(BizEventToReceiptService bizEventToReceiptService,
+                                  BizEventCosmosClient bizEventCosmosClient,
+                                  ReceiptCosmosService receiptCosmosService) {
+        this.bizEventToReceiptService = bizEventToReceiptService;
+        this.bizEventCosmosClient = bizEventCosmosClient;
+        this.receiptCosmosService = receiptCosmosService;
+    }
+
+    /**
+     * This function will be invoked periodically according to the specified schedule.
+     */
+    @FunctionName("RecoverFailedReceiptScheduled")
+    public void run(
+            @TimerTrigger(name = "timerInfo", schedule = "%RECOVER_FAILED_CRON%") String timerInfo,
+            @CosmosDBOutput(
+                    name = "ReceiptDatastore",
+                    databaseName = "db",
+                    collectionName = "receipts",
+                    connectionStringSetting = "COSMOS_RECEIPTS_CONN_STRING")
+            OutputBinding<List<Receipt>> documentdb,
+            final ExecutionContext context
+    ) {
+        logger.info("[{}] function called at {}", context.getFunctionName(), LocalDateTime.now());
+        List<Receipt> receiptList = new ArrayList<>();
+
+        receiptList.addAll(recoverFailed(context, ReceiptStatusType.INSERTED));
+        receiptList.addAll(recoverFailed(context, ReceiptStatusType.FAILED));
+        receiptList.addAll(recoverFailed(context, ReceiptStatusType.NOT_QUEUE_SENT));
+
+        documentdb.setValue(receiptList);
+    }
+
+    private List<Receipt> recoverFailed(ExecutionContext context, ReceiptStatusType statusType) {
+        try {
+            return recover(context, statusType);
+        } catch (NoSuchElementException e) {
+            logger.error("[{}] Unexpected error during recover of failed receipt for status {}",
+                    context.getFunctionName(), statusType, e);
+            return Collections.emptyList();
+        }
+    }
+
+    private List<Receipt> recover(ExecutionContext context, ReceiptStatusType statusType) {
+        int errorCounter = 0;
+        List<Receipt> receiptList = new ArrayList<>();
+        String continuationToken = null;
+        do {
+            Iterable<FeedResponse<Receipt>> feedResponseIterator =
+                    this.receiptCosmosService.getFailedReceiptByStatus(continuationToken, 100, statusType);
+
+            for (FeedResponse<Receipt> page : feedResponseIterator) {
+                for (Receipt receipt : page.getResults()) {
+                    try {
+                        Receipt restored = getEvent(receipt.getEventId(), context, this.bizEventToReceiptService,
+                                this.bizEventCosmosClient, this.receiptCosmosService, receipt, logger);
+                        receiptList.add(restored);
+                    } catch (Exception e) {
+                        logger.error(e.getMessage(), e);
+                        errorCounter++;
+                    }
+                }
+                continuationToken = page.getContinuationToken();
+            }
+        } while (continuationToken != null);
+        if (errorCounter > 0) {
+            logger.error("[{}] Error recovering {} failed receipt for status {}",
+                    context.getFunctionName(), errorCounter, statusType);
+        }
+        return receiptList;
+    }
+}

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceipt.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceipt.java
@@ -53,7 +53,7 @@ public class RecoverNotNotifiedReceipt {
      * not triggered ({@link ReceiptStatusType#GENERATED} by clearing the errors and update the status to the
      * previous step ({@link ReceiptStatusType#GENERATED}).
      *
-     * @return response with {@link HttpStatus#OK} if the notification succeeded
+     * @return response with {@link HttpStatus#OK} if the operation succeeded
      */
     @FunctionName("RecoverNotNotifiedReceipt")
     public HttpResponseMessage run(

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceiptMassive.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverNotNotifiedReceiptMassive.java
@@ -50,7 +50,7 @@ public class RecoverNotNotifiedReceiptMassive {
      * not triggered ({@link ReceiptStatusType#GENERATED} by clearing the errors and update the status to the
      * previous step ({@link ReceiptStatusType#GENERATED}).
      *
-     * @return response with {@link HttpStatus#OK} if the notification succeeded
+     * @return response with {@link HttpStatus#OK} if the operation succeeded
      */
     @FunctionName("RecoverNotNotifiedReceiptMassive")
     public HttpResponseMessage run(

--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/model/MassiveRecoverResult.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/model/MassiveRecoverResult.java
@@ -1,0 +1,15 @@
+package it.gov.pagopa.receipt.pdf.helpdesk.model;
+
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class MassiveRecoverResult {
+
+    private List<Receipt> receiptList;
+    private int errorCounter;
+}

--- a/src/test/java/it/gov/pagopa/receipt/pdf/helpdesk/GetReceiptErrorTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/helpdesk/GetReceiptErrorTest.java
@@ -114,7 +114,7 @@ class GetReceiptErrorTest {
 
         // test assertion
         assertNotNull(response);
-        assertEquals(HttpStatus.OK, response.getStatus());
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatus());
         assertEquals(ProblemJson.class, response.getBody().getClass());
 
         ProblemJson responseData = (ProblemJson) response.getBody();

--- a/src/test/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptScheduledTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/helpdesk/RecoverFailedReceiptScheduledTest.java
@@ -1,0 +1,179 @@
+package it.gov.pagopa.receipt.pdf.helpdesk;
+
+import com.azure.cosmos.models.ModelBridgeInternal;
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.OutputBinding;
+import it.gov.pagopa.receipt.pdf.helpdesk.client.impl.BizEventCosmosClientImpl;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.event.BizEvent;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.event.Debtor;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.event.Payer;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.event.PaymentInfo;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.event.Transaction;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.event.TransactionDetails;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.event.enumeration.BizEventStatusType;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.CartItem;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.EventData;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.Receipt;
+import it.gov.pagopa.receipt.pdf.helpdesk.entity.receipt.enumeration.ReceiptStatusType;
+import it.gov.pagopa.receipt.pdf.helpdesk.exception.BizEventNotFoundException;
+import it.gov.pagopa.receipt.pdf.helpdesk.service.BizEventToReceiptService;
+import it.gov.pagopa.receipt.pdf.helpdesk.service.ReceiptCosmosService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RecoverFailedReceiptScheduledTest {
+
+    private final String TOKENIZED_DEBTOR_FISCAL_CODE = "tokenizedDebtorFiscalCode";
+    private final String TOKENIZED_PAYER_FISCAL_CODE = "tokenizedPayerFiscalCode";
+    private final String EVENT_ID_1 = "a valid id 1";
+    private final String EVENT_ID_2 = "a valid id 2";
+    private final String EVENT_ID_3 = "a valid id 3";
+
+    @Mock
+    private ExecutionContext contextMock;
+    @Mock
+    private ReceiptCosmosService receiptCosmosServiceMock;
+    @Mock
+    private BizEventCosmosClientImpl bizEventCosmosClientMock;
+    @Mock
+    private BizEventToReceiptService bizEventToReceiptServiceMock;
+
+    @Captor
+    private ArgumentCaptor<List<Receipt>> receiptCaptor;
+
+    @Spy
+    private OutputBinding<List<Receipt>> documentdb;
+
+    private AutoCloseable closeable;
+
+    private RecoverFailedReceiptScheduled sut;
+
+    @BeforeEach
+    public void openMocks() {
+        closeable = MockitoAnnotations.openMocks(this);
+        sut = spy(new RecoverFailedReceiptScheduled(bizEventToReceiptServiceMock, bizEventCosmosClientMock, receiptCosmosServiceMock));
+    }
+
+    @AfterEach
+    public void releaseMocks() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    void recoverFailedReceiptScheduledSuccess() throws BizEventNotFoundException {
+        when(receiptCosmosServiceMock.getFailedReceiptByStatus(any(), any(), eq(ReceiptStatusType.FAILED)))
+                .thenReturn(Collections.singletonList(ModelBridgeInternal
+                        .createFeedResponse(Collections.singletonList(
+                                createFailedReceipt(EVENT_ID_1, ReceiptStatusType.FAILED)),
+                                Collections.emptyMap())));
+        when(receiptCosmosServiceMock.getFailedReceiptByStatus(any(), any(), eq(ReceiptStatusType.INSERTED)))
+                .thenReturn(Collections.singletonList(ModelBridgeInternal
+                        .createFeedResponse(Collections.singletonList(
+                                createFailedReceipt(EVENT_ID_2, ReceiptStatusType.INSERTED)),
+                                Collections.emptyMap())));
+        when(receiptCosmosServiceMock.getFailedReceiptByStatus(any(), any(), eq(ReceiptStatusType.NOT_QUEUE_SENT)))
+                .thenReturn(Collections.singletonList(ModelBridgeInternal
+                        .createFeedResponse(Collections.singletonList(
+                                createFailedReceipt(EVENT_ID_3, ReceiptStatusType.NOT_QUEUE_SENT)),
+                                Collections.emptyMap())));
+
+        when(bizEventCosmosClientMock.getBizEventDocument(EVENT_ID_1))
+                .thenReturn(generateValidBizEvent(EVENT_ID_1));
+        when(bizEventCosmosClientMock.getBizEventDocument(EVENT_ID_2))
+                .thenReturn(generateValidBizEvent(EVENT_ID_2));
+        when(bizEventCosmosClientMock.getBizEventDocument(EVENT_ID_3))
+                .thenReturn(generateValidBizEvent(EVENT_ID_3));
+
+        // test execution
+        assertDoesNotThrow(() -> sut.run("info", documentdb, contextMock));
+
+        verify(documentdb).setValue(receiptCaptor.capture());
+        assertEquals(3, receiptCaptor.getValue().size());
+
+        Receipt captured = receiptCaptor.getValue().get(0);
+        assertEquals(ReceiptStatusType.INSERTED, captured.getStatus());
+        assertEquals(TOKENIZED_PAYER_FISCAL_CODE, captured.getEventData().getPayerFiscalCode());
+        assertEquals(TOKENIZED_DEBTOR_FISCAL_CODE, captured.getEventData().getDebtorFiscalCode());
+        assertNotNull(captured.getEventData().getCart());
+        assertEquals(1, captured.getEventData().getCart().size());
+
+        captured = receiptCaptor.getValue().get(1);
+        assertEquals(ReceiptStatusType.INSERTED, captured.getStatus());
+        assertEquals(TOKENIZED_PAYER_FISCAL_CODE, captured.getEventData().getPayerFiscalCode());
+        assertEquals(TOKENIZED_DEBTOR_FISCAL_CODE, captured.getEventData().getDebtorFiscalCode());
+        assertNotNull(captured.getEventData().getCart());
+        assertEquals(1, captured.getEventData().getCart().size());
+
+        captured = receiptCaptor.getValue().get(2);
+        assertEquals(ReceiptStatusType.INSERTED, captured.getStatus());
+        assertEquals(TOKENIZED_PAYER_FISCAL_CODE, captured.getEventData().getPayerFiscalCode());
+        assertEquals(TOKENIZED_DEBTOR_FISCAL_CODE, captured.getEventData().getDebtorFiscalCode());
+        assertNotNull(captured.getEventData().getCart());
+        assertEquals(1, captured.getEventData().getCart().size());
+    }
+
+    private BizEvent generateValidBizEvent(String eventId){
+        BizEvent item = new BizEvent();
+
+        Payer payer = new Payer();
+        payer.setEntityUniqueIdentifierValue("a valid payer CF");
+        Debtor debtor = new Debtor();
+        debtor.setEntityUniqueIdentifierValue("a valid debtor CF");
+
+        TransactionDetails transactionDetails = new TransactionDetails();
+        Transaction transaction = new Transaction();
+        transaction.setCreationDate(String.valueOf(LocalDateTime.now()));
+        transactionDetails.setTransaction(transaction);
+
+        PaymentInfo paymentInfo = new PaymentInfo();
+        paymentInfo.setTotalNotice("1");
+
+        item.setEventStatus(BizEventStatusType.DONE);
+        item.setId(eventId);
+        item.setPayer(payer);
+        item.setDebtor(debtor);
+        item.setTransactionDetails(transactionDetails);
+        item.setPaymentInfo(paymentInfo);
+
+        return item;
+    }
+
+    private Receipt createFailedReceipt(String id, ReceiptStatusType statusType) {
+        Receipt receipt = new Receipt();
+
+        receipt.setId(id);
+        receipt.setEventId(id);
+        receipt.setVersion("1");
+
+        receipt.setStatus(statusType);
+        EventData eventData = new EventData();
+        eventData.setDebtorFiscalCode(TOKENIZED_DEBTOR_FISCAL_CODE);
+        eventData.setPayerFiscalCode(TOKENIZED_PAYER_FISCAL_CODE);
+        receipt.setEventData(eventData);
+
+        CartItem item = new CartItem();
+        List<CartItem> cartItems = Collections.singletonList(item);
+        eventData.setCart(cartItems);
+
+        return receipt;
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- added timer trigger function for recovering receipt in status `INSERTED`, `FAILED` and `NOT_QUEUE_SENT`
- added new env  `RECOVER_FAILED_CRON`
- fixed recover failed logic for status `NOT_QUEUE_SENT`
- added unit tests

#### Motivation and Context
Automatically recover receipts in failed status
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.