### PR TITLE
[fix] Fixed payer fiscal code check when discarding events

### DIFF
--- a/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/utils/BizEventToReceiptUtils.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/helpdesk/utils/BizEventToReceiptUtils.java
@@ -147,7 +147,7 @@ public class BizEventToReceiptUtils {
                     try {
                         Receipt restored = getEvent(receipt.getEventId(), context, bizEventToReceiptService,
                                 bizEventCosmosClient, receiptCosmosService, receipt, logger, receipt.getIsCart() != null ?
-                                receipt.getIsCart() : false);
+                                        receipt.getIsCart() : false);
                         receiptList.add(restored);
                     } catch (Exception e) {
                         logger.error(e.getMessage(), e);
@@ -233,11 +233,7 @@ public class BizEventToReceiptUtils {
             return true;
         }
 
-        if (
-                (bizEvent.getDebtor() == null || !isValidFiscalCode(bizEvent.getDebtor().getEntityUniqueIdentifierValue()))
-                        &&
-                        (bizEvent.getPayer() == null || !isValidFiscalCode(bizEvent.getPayer().getEntityUniqueIdentifierValue()))
-        ) {
+        if (!hasValidFiscalCode(bizEvent)) {
             logger.debug("[{}] event with id {} discarded because debtor's and payer's identifiers are missing or not valid",
                     context.getFunctionName(), bizEvent.getId());
             return true;
@@ -270,6 +266,23 @@ public class BizEventToReceiptUtils {
         }
 
         return false;
+    }
+
+    private static boolean hasValidFiscalCode(BizEvent bizEvent) {
+        boolean isValidDebtor = false;
+        boolean isValidPayer = false;
+
+        if(bizEvent.getDebtor() != null && isValidFiscalCode(bizEvent.getDebtor().getEntityUniqueIdentifierValue())){
+            isValidDebtor = true;
+        }
+        if(bizEvent.getTransactionDetails() != null && bizEvent.getTransactionDetails().getUser() != null && isValidFiscalCode(bizEvent.getTransactionDetails().getUser().getFiscalCode())){
+            isValidPayer = true;
+        }
+        if(bizEvent.getPayer() != null && isValidFiscalCode(bizEvent.getPayer().getEntityUniqueIdentifierValue())){
+            isValidPayer = true;
+        }
+
+        return isValidDebtor || isValidPayer;
     }
 
     public static void tokenizeReceipt(BizEventToReceiptService service, List<BizEvent> bizEvents, Receipt receipt)
@@ -447,5 +460,6 @@ public class BizEventToReceiptUtils {
         return false;
     }
 
-    private BizEventToReceiptUtils() {}
+    private BizEventToReceiptUtils() {
+    }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Fixed payer validation when checking for bizEvent validity

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The payer fiscal code was checked only in payer.entityUniqueIdentifierValue and not in transactionDetails.user

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.