### PR TITLE
[PIDM-380] fix: integration test runner

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -26,31 +26,9 @@ permissions:
 
 
 jobs:
-  create_runner:
-    name: Create Runner
-    runs-on: ubuntu-22.04
-    environment:
-      name: ${{(github.event.inputs == null && 'uat') || inputs.environment }}
-    outputs:
-      runner_name: ${{ steps.create_github_runner.outputs.runner_name }}
-    steps:
-      - name: Create GitHub Runner
-        id: create_github_runner
-        # from https://github.com/pagopa/eng-github-actions-iac-template/tree/main/azure/github-self-hosted-runner-azure-create-action
-        uses: pagopa/eng-github-actions-iac-template/azure/github-self-hosted-runner-azure-create-action@main
-        with:
-          client_id: ${{ secrets.CD_CLIENT_ID }}
-          tenant_id: ${{ secrets.TENANT_ID }}
-          subscription_id: ${{ secrets.SUBSCRIPTION_ID }}
-          container_app_environment_name: ${{ vars.CONTAINER_APP_ENVIRONMENT_NAME }}
-          resource_group_name: ${{ vars.CONTAINER_APP_ENVIRONMENT_RESOURCE_GROUP_NAME }} # RG of the runner
-          pat_token: ${{ secrets.BOT_TOKEN_GITHUB }}
-          # self_hosted_runner_image_tag: "v1.6.0"
-
   integration_test:
-    needs: [ create_runner ]
     name: Test ${{(github.event.inputs == null && 'uat') || inputs.environment }}
-    runs-on: [ self-hosted, "${{ needs.create_runner.outputs.runner_name }}" ]
+    runs-on: [ self-hosted, self-hosted-job, uat ]
     environment: ${{(github.event.inputs == null && 'uat') || inputs.environment }}
     steps:
 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   integration_test:
     name: Test ${{(github.event.inputs == null && 'uat') || inputs.environment }}
-    runs-on: [ self-hosted, self-hosted-job, uat ]
+    runs-on: [ self-hosted, self-hosted-job, ${{ inputs.environment || 'uat' }} ]
     environment: ${{(github.event.inputs == null && 'uat') || inputs.environment }}
     steps:
 
@@ -70,8 +70,8 @@ jobs:
           ./run_teardown.sh ${{( github.event.inputs == null && 'uat') || inputs.environment }}
 
   notify:
-    needs: [ create_runner, integration_test ]
-    runs-on: [ self-hosted, "${{ needs.create_runner.outputs.runner_name }}" ]
+    needs: [ integration_test ]
+    runs-on: [ self-hosted, self-hosted-job, ${{ inputs.environment || 'uat' }} ]
     name: Notify
     if: ${{ always() && (github.event_name == 'schedule' || inputs.notify == true ) }}
     steps:
@@ -86,22 +86,3 @@ jobs:
           footer: 'Linked to <{workflow_url}| workflow file>'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  cleanup_runner:
-    name: Cleanup Runner
-    needs: [ create_runner, integration_test ]
-    if: ${{ always() }}
-    runs-on: ubuntu-22.04
-    environment: ${{(github.event.inputs == null && 'uat') || inputs.environment }}
-    steps:
-      - name: Cleanup GitHub Runner
-        id: cleanup_github_runner
-        # from https://github.com/pagopa/eng-github-actions-iac-template/tree/main/azure/github-self-hosted-runner-azure-cleanup-action
-        uses: pagopa/eng-github-actions-iac-template/azure/github-self-hosted-runner-azure-cleanup-action@0ee2f58fd46d10ac7f00bce4304b98db3dbdbe9a
-        with:
-          client_id: ${{ secrets.CD_CLIENT_ID }}
-          tenant_id: ${{ secrets.TENANT_ID }}
-          subscription_id: ${{ secrets.SUBSCRIPTION_ID }}
-          resource_group_name: ${{ vars.CONTAINER_APP_ENVIRONMENT_RESOURCE_GROUP_NAME }}
-          runner_name: ${{ needs.create_runner.outputs.runner_name }}
-          pat_token: ${{ secrets.BOT_TOKEN_GITHUB }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      notify:
+        required: false
+        type: boolean
+        description: 'send the slack notification'
+        default: false
 
 permissions:
   id-token: write
@@ -27,9 +32,9 @@ permissions:
 
 jobs:
   integration_test:
-    name: Test ${{(github.event.inputs == null && 'uat') || inputs.environment }}
-    runs-on: [ self-hosted, self-hosted-job, ${{ inputs.environment || 'uat' }} ]
-    environment: ${{(github.event.inputs == null && 'uat') || inputs.environment }}
+    name: Test ${{ github.event.inputs == null && 'uat' || github.event.inputs.environment }}
+    runs-on: [ self-hosted, self-hosted-job, "${{ github.event.inputs == null && 'uat' || github.event.inputs.environment }}" ]
+    environment: ${{ github.event.inputs == null && 'uat' || github.event.inputs.environment }}
     steps:
 
       - name: Checkout
@@ -55,7 +60,7 @@ jobs:
           export SUBKEY='${{ secrets.SUBKEY }}'
           cd ./integration-test
           chmod +x ./run_integration_test.sh
-          ./run_integration_test.sh ${{( github.event.inputs == null && 'uat') || inputs.environment }}
+          ./run_integration_test.sh ${{ github.event.inputs == null && 'uat' || github.event.inputs.environment }}
 
       - name: Teardown integration tests
         shell: bash
@@ -67,13 +72,13 @@ jobs:
           export RECEIPTS_STORAGE_CONN_STRING='${{ secrets.RECEIPTS_STORAGE_CONN_STRING }}'
           cd ./integration-test
           chmod +x ./run_teardown.sh
-          ./run_teardown.sh ${{( github.event.inputs == null && 'uat') || inputs.environment }}
+          ./run_teardown.sh ${{ github.event.inputs == null && 'uat' || github.event.inputs.environment }}
 
   notify:
     needs: [ integration_test ]
-    runs-on: [ self-hosted, self-hosted-job, ${{ inputs.environment || 'uat' }} ]
+    runs-on: [ self-hosted, self-hosted-job, "${{ github.event.inputs == null && 'uat' || github.event.inputs.environment }}" ]
     name: Notify
-    if: ${{ always() && (github.event_name == 'schedule' || inputs.notify == true ) }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event.inputs.notify == true ) }}
     steps:
       - name: Report Status
         uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
@@ -81,7 +86,7 @@ jobs:
           status: ${{ needs.integration_test.result }}
           token: ${{ secrets.GITHUB_TOKEN }}
           notify_when: 'failure,skipped'
-          notification_title: "<{run_url}|Scheduled Integration Test> has {status_message} in ${{( github.event.inputs == null && 'uat') || inputs.environment }} env"
+          notification_title: "<{run_url}|Scheduled Integration Test> has {status_message} in ${{ github.event.inputs == null && 'uat' || github.event.inputs.environment }} env"
           message_format: '{emoji} <{run_url}|{workflow}> {status_message} in <{repo_url}|{repo}>'
           footer: 'Linked to <{workflow_url}| workflow file>'
         env:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -26,9 +26,31 @@ permissions:
 
 
 jobs:
+  create_runner:
+    name: Create Runner
+    runs-on: ubuntu-22.04
+    environment:
+      name: ${{(github.event.inputs == null && 'uat') || inputs.environment }}
+    outputs:
+      runner_name: ${{ steps.create_github_runner.outputs.runner_name }}
+    steps:
+      - name: Create GitHub Runner
+        id: create_github_runner
+        # from https://github.com/pagopa/eng-github-actions-iac-template/tree/main/azure/github-self-hosted-runner-azure-create-action
+        uses: pagopa/eng-github-actions-iac-template/azure/github-self-hosted-runner-azure-create-action@main
+        with:
+          client_id: ${{ secrets.CD_CLIENT_ID }}
+          tenant_id: ${{ secrets.TENANT_ID }}
+          subscription_id: ${{ secrets.SUBSCRIPTION_ID }}
+          container_app_environment_name: ${{ vars.CONTAINER_APP_ENVIRONMENT_NAME }}
+          resource_group_name: ${{ vars.CONTAINER_APP_ENVIRONMENT_RESOURCE_GROUP_NAME }} # RG of the runner
+          pat_token: ${{ secrets.BOT_TOKEN_GITHUB }}
+          # self_hosted_runner_image_tag: "v1.6.0"
+
   integration_test:
+    needs: [ create_runner ]
     name: Test ${{(github.event.inputs == null && 'uat') || inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, "${{ needs.create_runner.outputs.runner_name }}" ]
     environment: ${{(github.event.inputs == null && 'uat') || inputs.environment }}
     steps:
 
@@ -70,8 +92,8 @@ jobs:
           ./run_teardown.sh ${{( github.event.inputs == null && 'uat') || inputs.environment }}
 
   notify:
-    needs: [ integration_test ]
-    runs-on: ubuntu-latest
+    needs: [ create_runner, integration_test ]
+    runs-on: [ self-hosted, "${{ needs.create_runner.outputs.runner_name }}" ]
     name: Notify
     if: ${{ always() && (github.event_name == 'schedule' || inputs.notify == true ) }}
     steps:
@@ -86,3 +108,22 @@ jobs:
           footer: 'Linked to <{workflow_url}| workflow file>'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  cleanup_runner:
+    name: Cleanup Runner
+    needs: [ create_runner, integration_test ]
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    environment: ${{(github.event.inputs == null && 'uat') || inputs.environment }}
+    steps:
+      - name: Cleanup GitHub Runner
+        id: cleanup_github_runner
+        # from https://github.com/pagopa/eng-github-actions-iac-template/tree/main/azure/github-self-hosted-runner-azure-cleanup-action
+        uses: pagopa/eng-github-actions-iac-template/azure/github-self-hosted-runner-azure-cleanup-action@0ee2f58fd46d10ac7f00bce4304b98db3dbdbe9a
+        with:
+          client_id: ${{ secrets.CD_CLIENT_ID }}
+          tenant_id: ${{ secrets.TENANT_ID }}
+          subscription_id: ${{ secrets.SUBSCRIPTION_ID }}
+          resource_group_name: ${{ vars.CONTAINER_APP_ENVIRONMENT_RESOURCE_GROUP_NAME }}
+          runner_name: ${{ needs.create_runner.outputs.runner_name }}
+          pat_token: ${{ secrets.BOT_TOKEN_GITHUB }}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Fixed runs-on configuration to properly use self-hosted runners
- Corrected environment specification for scheduled and manual workflow runs
- Added missing notify input parameter

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fixes integration test failures that occur when using github-hosted runners, which can't access Cosmos DB due to firewall restrictions. Self-hosted Azure runners work properly because they run within the Azure environment network.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Confirmed workflow executes on correct runners
- Verified tests run within the proper network context

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.